### PR TITLE
Add Video & Audio Icons to Downloads Nav Bar

### DIFF
--- a/Controllers/DownloadsController.m
+++ b/Controllers/DownloadsController.m
@@ -19,10 +19,12 @@
 
     DownloadsVideoController *videoViewController = [[DownloadsVideoController alloc] init];
     videoViewController.title = @"Video";
+    videoViewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Video" image:[UIImage systemImageNamed:@"video.circle.fill"] tag:0];
     UINavigationController *videoNavViewController = [[UINavigationController alloc] initWithRootViewController:videoViewController];
 
     DownloadsAudioController *audioViewController = [[DownloadsAudioController alloc] init];
     audioViewController.title = @"Audio";
+    audioViewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Audio" image:[UIImage systemImageNamed:@"music.note"] tag:1];
     UINavigationController *audioNavViewController = [[UINavigationController alloc] initWithRootViewController:audioViewController];
 
     self.tabBar.viewControllers = [NSArray arrayWithObjects:videoNavViewController, audioNavViewController, nil];


### PR DESCRIPTION
Hey LillieH1000. I am here to contribute once again, This time my pull request is just something for the v5 beta that adds Video & Audio icons in the **View Downloads** Bar. And I would like to apologize about last time. I did make an apology and improved it in my pinned discussion below in my fork.
https://github.com/arichornlover/YouTube-Reborn/discussions/3

But was also wondering. What do you think about the simple changes? I just hope this doesn’t end up like those previous pull requests if you remembered.

![preview](https://github.com/LillieH1000/YouTube-Reborn/assets/157071384/559d1a4a-8b93-490f-a62a-671dfa1c6c1a)

And knowing that I might possibly lose the ability to speak like last time, I do want to let you know on something else.

**LillieH1000**, you did a pretty good job with the tweak and especially helping out and just hoped you deserved way more support for what you do, you are a genuinely good developer.